### PR TITLE
require 'rails_helper'

### DIFF
--- a/spec/views/songs/edit.html.erb_spec.rb
+++ b/spec/views/songs/edit.html.erb_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'songs/edit', type: :feature do
   let(:song_attributes) do
     {

--- a/spec/views/songs/index.html.erb_spec.rb
+++ b/spec/views/songs/index.html.erb_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'songs/index', type: :feature do
   let(:song_attributes_1) do
     {

--- a/spec/views/songs/new.html.erb_spec.rb
+++ b/spec/views/songs/new.html.erb_spec.rb
@@ -1,3 +1,5 @@
+require 'rails_helper'
+
 RSpec.describe 'songs/new', type: :feature do
   it 'renders form' do
     visit new_song_path


### PR DESCRIPTION
At a glance, I am not entirely sure what was wrong with the lab. I do know the `edit.html.erb_spec.rb`, `index.html.erb_spec.rb` and the `new.html.erb_spec.rb` files we unware of the rest of the Rails app. 

Adding `require 'rails_helper'` seems to be a straightforward solution for now. I'm open to better ways of handling this.